### PR TITLE
Fix no associated program error in XP for .bat files

### DIFF
--- a/gui-packed/guitools.vbs
+++ b/gui-packed/guitools.vbs
@@ -44,12 +44,12 @@ ElseIf value = 3 Then
 'Option 4 will add the system start task.
 ElseIf value = 4 Then  
     Set objShell = CreateObject("Shell.Application")
-    objShell.ShellExecute oShell.CurrentDirectory & "\ka-lite\scripts\add_systemstart_task.bat", "", "", "runas", 1
+    objShell.ShellExecute "cmd.exe", "/c """ & oShell.CurrentDirectory & "\ka-lite\scripts\add_systemstart_task.bat""", "", "runas", 1
 
 'Option 5 will remove the system start task.    
 ElseIf value = 5 Then
     Set objShell = CreateObject("Shell.Application")
-    objShell.ShellExecute oShell.CurrentDirectory & "\ka-lite\scripts\remove_systemstart_task.bat", "", "", "runas", 1
+    objShell.ShellExecute "cmd.exe", "/c """ & oShell.CurrentDirectory & "\ka-lite\scripts\remove_systemstart_task.bat""", "", "runas", 1
     
 End If
 


### PR DESCRIPTION
This should work on all flavors of Windows. But it would be nice to build the installer and test it out on XP, 7, and 8. No need to go through the whole installation process, just check "Start at system boot" option and ensure that the script runs instead of giving a "No associated application" error, then you can abort the installation.