### PR TITLE
Exclude the `data.sqlite` when building and packaging the `ka-lite` source into the installer.

### DIFF
--- a/installer-source/KaliteSetupScript.iss
+++ b/installer-source/KaliteSetupScript.iss
@@ -36,7 +36,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\ka-lite\*"; DestDir: "{app}\ka-lite"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\ka-lite\*"; DestDir: "{app}\ka-lite"; Excludes: "data.sqlite"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\ka-lite\content\*"; DestDir: "{app}\ka-lite\content"; Flags: ignoreversion recursesubdirs createallsubdirs uninsneveruninstall
 Source: "..\ka-lite\kalite\database\*"; DestDir: "{app}\ka-lite\kalite\database"; Excludes: "data.sqlite"; Flags: ignoreversion recursesubdirs createallsubdirs uninsneveruninstall
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion

--- a/installer-source/KaliteSetupScript.iss
+++ b/installer-source/KaliteSetupScript.iss
@@ -38,7 +38,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "..\ka-lite\*"; DestDir: "{app}\ka-lite"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\ka-lite\content\*"; DestDir: "{app}\ka-lite\content"; Flags: ignoreversion recursesubdirs createallsubdirs uninsneveruninstall
-Source: "..\ka-lite\kalite\database\*"; DestDir: "{app}\ka-lite\kalite\database"; Flags: ignoreversion recursesubdirs createallsubdirs uninsneveruninstall
+Source: "..\ka-lite\kalite\database\*"; DestDir: "{app}\ka-lite\kalite\database"; Excludes: "data.sqlite"; Flags: ignoreversion recursesubdirs createallsubdirs uninsneveruninstall
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\guitools.vbs"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\images\logo48.ico"; DestDir: "{app}\images"; Flags: ignoreversion


### PR DESCRIPTION
Hi @aronasorman - this fixes #59 - Ignore data.sqlite.

I've added an `Excludes: "data.sqlite"` for every entry under the `[Files]` section that could possibly contain the `database` directory.

I manually tested by doing these:

1. Create a `data.sqlite` file inside the `ka-lite\kalite\database\` sub-module directory.
2. Build and run the installer.
3. While the installer is copying files, monitor the `C:\Program Files\KA Lite\ka-lite\kalite\database\` folder and notice that the `data.sqlite` file is not there.

See screenshot
![ka-lite-installer](https://cloud.githubusercontent.com/assets/175580/6708173/fd065b58-cda8-11e4-9bff-0e68886fafd0.png)
